### PR TITLE
Equalize banner and container sizes

### DIFF
--- a/logo.html
+++ b/logo.html
@@ -10,16 +10,23 @@
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
         
+        .container {
+            position: relative;
+            width: 100%;
+            height: 0;
+            padding-bottom: 16.67%;
+            margin-bottom: 40px;
+        }
+        
         .banner {
             background: linear-gradient(135deg, #116517, #146a1e);
             border-radius: 15px;
             box-shadow: 0 15px 30px rgba(13, 99, 6, 0.5);
             overflow: hidden;
-            position: relative;
+            position: absolute;
+            inset: 0;
             width: 100%;
-            height: 0;
-            padding-bottom: 16.67%; /* Half of original 33.33% = 16.67% */
-            margin-bottom: 40px;
+            height: 100%;
         }
         
         .banner-content {
@@ -83,7 +90,7 @@
         }
         
         @media (max-width: 768px) {
-            .banner {
+            .container {
                 padding-bottom: 25%; /* Half of original 50% = 25% */
             }
             
@@ -132,6 +139,11 @@
                 </div>
                 <h1 class="company-name">Greenperth Global Industries</h1>
                 <p class="tagline">Creating captivating Caring</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
 
 
 


### PR DESCRIPTION
Align `.container` and `.banner` sizes by making `.container` define the aspect ratio and `.banner` fill it.

The `.container` now uses the `padding-bottom` aspect ratio technique, and the `.banner` is absolutely positioned to fill its parent (`.container`). Media queries were updated to target `.container` for responsive adjustments, and missing HTML closing tags were added for validity.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e0989b4-1673-43a7-a54e-63f2c9393417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e0989b4-1673-43a7-a54e-63f2c9393417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

